### PR TITLE
Only Apply Sensor Divisor to Numerical Values

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,9 +49,18 @@ socket.on('open', () => {
     }
 
     const topic = `${sensor.topic}`
-    const dataType = `${sensor.data}`
-    const value = sensorData.state[dataType] / sensor.divisor;
-    
+
+    var value = sensorData.state[`${sensor.data}`]
+
+    const isInt = value === parseInt(value)
+    const isFloat = value === parseFloat(value)
+    const isNumeric = isInt || isFloat
+    const hasDivisor = !(sensor.divisor === undefined)
+
+    if (isNumeric && hasDivisor) {
+      value /= sensor.divisor
+    }
+
     console.log(`topic: ${topic} data: ${value}`)
 
     if (mqttConnected) {


### PR DESCRIPTION
Updates the app logic to only apply the sensor divisor to numerical values.

This allows string & boolean values to be broadcast as well.